### PR TITLE
Update gem name to scss_lint

### DIFF
--- a/lib/scss-lint.js
+++ b/lib/scss-lint.js
@@ -172,7 +172,7 @@ var SCSSLint = {
     }
 
     if (!shell.which('scss-lint')) {
-      throw new Error('"scss-lint" does not exist in the system. Please install "scss-lint" (gem install scss-lint).');
+      throw new Error('"scss-lint" does not exist in the system. Please install "scss-lint" (gem install scss_lint).');
     }
 
     options.format.forEach(function (f) {


### PR DESCRIPTION
scss-lint has changed the gem name from scss-lint to scss_lint.  This PR simply changes the warning message that displays so that the user knows the proper gem to install.
